### PR TITLE
remove start command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && npm run start",
+  "postCreateCommand": "npm install",
 
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node",


### PR DESCRIPTION
As of right now, starting a long-running process like one via `npm start` doesn’t resolve in the terminal. So if the user wants to cancel the dev server, the port will remain locked in the background and the only way to kill it would be to run `lsof -i tcp:<PORT>`.

I recommend not starting the server automatically until https://github.com/devcontainers/spec/issues/83 is resolved.